### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostPredefConfig.cmake
+++ b/BoostPredefConfig.cmake
@@ -1,0 +1,6 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostPredefTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
+
+project(BoostPredef VERSION 1.66 LANGUAGES CXX)
+
+add_library(predef INTERFACE)
+
+target_include_directories(predef INTERFACE 
+    $<BUILD_INTERFACE:${BoostPredef_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostPredef_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+install(EXPORT predef-targets
+    FILE BoostPredefTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS predef EXPORT predef-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostPredefConfigVersion.cmake"
+    VERSION ${BoostPredef_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostPredefConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostPredefConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::predef ALIAS predef)


### PR DESCRIPTION
Expresses Boost::predef as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostPredef 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── detail
│       │   └── endian.hpp
│       ├── predef
│       │   ├── architecture
│       │   │   ├── alpha.h
│       │   │   ├── arm.h
│       │   │   ├── blackfin.h
│       │   │   ├── convex.h
│       │   │   ├── ia64.h
│       │   │   ├── m68k.h
│       │   │   ├── mips.h
│       │   │   ├── parisc.h
│       │   │   ├── ppc.h
│       │   │   ├── pyramid.h
│       │   │   ├── rs6k.h
│       │   │   ├── sparc.h
│       │   │   ├── superh.h
│       │   │   ├── sys370.h
│       │   │   ├── sys390.h
│       │   │   ├── x86
│       │   │   │   ├── 32.h
│       │   │   │   └── 64.h
│       │   │   ├── x86.h
│       │   │   └── z.h
│       │   ├── architecture.h
│       │   ├── compiler
│       │   │   ├── borland.h
│       │   │   ├── clang.h
│       │   │   ├── comeau.h
│       │   │   ├── compaq.h
│       │   │   ├── diab.h
│       │   │   ├── digitalmars.h
│       │   │   ├── dignus.h
│       │   │   ├── edg.h
│       │   │   ├── ekopath.h
│       │   │   ├── gcc.h
│       │   │   ├── gcc_xml.h
│       │   │   ├── greenhills.h
│       │   │   ├── hp_acc.h
│       │   │   ├── iar.h
│       │   │   ├── ibm.h
│       │   │   ├── intel.h
│       │   │   ├── kai.h
│       │   │   ├── llvm.h
│       │   │   ├── metaware.h
│       │   │   ├── metrowerks.h
│       │   │   ├── microtec.h
│       │   │   ├── mpw.h
│       │   │   ├── palm.h
│       │   │   ├── pgi.h
│       │   │   ├── sgi_mipspro.h
│       │   │   ├── sunpro.h
│       │   │   ├── tendra.h
│       │   │   ├── visualc.h
│       │   │   └── watcom.h
│       │   ├── compiler.h
│       │   ├── detail
│       │   │   ├── _cassert.h
│       │   │   ├── comp_detected.h
│       │   │   ├── endian_compat.h
│       │   │   ├── _exception.h
│       │   │   ├── os_detected.h
│       │   │   ├── platform_detected.h
│       │   │   ├── test_def.h
│       │   │   └── test.h
│       │   ├── hardware
│       │   │   ├── simd
│       │   │   │   ├── arm
│       │   │   │   │   └── versions.h
│       │   │   │   ├── arm.h
│       │   │   │   ├── ppc
│       │   │   │   │   └── versions.h
│       │   │   │   ├── ppc.h
│       │   │   │   ├── x86
│       │   │   │   │   └── versions.h
│       │   │   │   ├── x86_amd
│       │   │   │   │   └── versions.h
│       │   │   │   ├── x86_amd.h
│       │   │   │   └── x86.h
│       │   │   └── simd.h
│       │   ├── hardware.h
│       │   ├── language
│       │   │   ├── objc.h
│       │   │   ├── stdc.h
│       │   │   └── stdcpp.h
│       │   ├── language.h
│       │   ├── library
│       │   │   ├── c
│       │   │   │   ├── cloudabi.h
│       │   │   │   ├── gnu.h
│       │   │   │   ├── _prefix.h
│       │   │   │   ├── uc.h
│       │   │   │   ├── vms.h
│       │   │   │   └── zos.h
│       │   │   ├── c.h
│       │   │   ├── std
│       │   │   │   ├── cxx.h
│       │   │   │   ├── dinkumware.h
│       │   │   │   ├── libcomo.h
│       │   │   │   ├── modena.h
│       │   │   │   ├── msl.h
│       │   │   │   ├── _prefix.h
│       │   │   │   ├── roguewave.h
│       │   │   │   ├── sgi.h
│       │   │   │   ├── stdcpp3.h
│       │   │   │   ├── stlport.h
│       │   │   │   └── vacpp.h
│       │   │   └── std.h
│       │   ├── library.h
│       │   ├── make.h
│       │   ├── os
│       │   │   ├── aix.h
│       │   │   ├── amigaos.h
│       │   │   ├── android.h
│       │   │   ├── beos.h
│       │   │   ├── bsd
│       │   │   │   ├── bsdi.h
│       │   │   │   ├── dragonfly.h
│       │   │   │   ├── free.h
│       │   │   │   ├── net.h
│       │   │   │   └── open.h
│       │   │   ├── bsd.h
│       │   │   ├── cygwin.h
│       │   │   ├── haiku.h
│       │   │   ├── hpux.h
│       │   │   ├── ios.h
│       │   │   ├── irix.h
│       │   │   ├── linux.h
│       │   │   ├── macos.h
│       │   │   ├── os400.h
│       │   │   ├── qnxnto.h
│       │   │   ├── solaris.h
│       │   │   ├── unix.h
│       │   │   ├── vms.h
│       │   │   └── windows.h
│       │   ├── os.h
│       │   ├── other
│       │   │   ├── endian.h
│       │   │   └── workaround.h
│       │   ├── other.h
│       │   ├── platform
│       │   │   ├── cloudabi.h
│       │   │   ├── ios.h
│       │   │   ├── mingw32.h
│       │   │   ├── mingw64.h
│       │   │   ├── mingw.h
│       │   │   ├── windows_desktop.h
│       │   │   ├── windows_phone.h
│       │   │   ├── windows_runtime.h
│       │   │   ├── windows_server.h
│       │   │   ├── windows_store.h
│       │   │   ├── windows_system.h
│       │   │   └── windows_uwp.h
│       │   ├── platform.h
│       │   ├── version.h
│       │   └── version_number.h
│       └── predef.h
└── lib
    └── cmake
        └── boost
            ├── BoostPredefConfig.cmake
            ├── BoostPredefConfigVersion.cmake
            └── BoostPredefTargets.cmake

25 directories, 140 files
```
- tests are __not__ included in the build